### PR TITLE
fix: Nix compatibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,29 @@
-use std::process::Command;
+use std::{
+    process::Command,
+    env,
+};
 
 fn main() {
-    // https://stackoverflow.com/a/44407625
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    // Check if we are in a Nix environment
+    // Nix does not work well with with variable compile-time outputs
+    // Git revision will be supplied correctly by the Nix build environment
+    // Compile DT will be the start of the UTC epoch
+    match env::var("NIX_BUILD_TOP"){
+        Ok(..) => println!("Nix builder detected, disabling non-deterministic compile time operations"),
+        Err(..) => {
+            // https://stackoverflow.com/a/44407625
+            let output = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap();
+            let git_hash = String::from_utf8(output.stdout).unwrap();
+            println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 
-    // Get compilation date / time
-    let dt_local = chrono::Local::now();
-    let naive_utc = dt_local.naive_utc();
-    let formatted = naive_utc.format("%Y-%m-%d %H:%M:%S");
-    println!("cargo:rustc-env=NAMIDA_COMPILE_DT={} UTC", formatted);
+            // Get compilation date / time
+            let dt_local = chrono::Local::now();
+            let naive_utc = dt_local.naive_utc();
+            let formatted = naive_utc.format("%Y-%m-%d %H:%M:%S");
+            println!("cargo:rustc-env=NAMIDA_COMPILE_DT={} UTC", formatted);
+        },
+    };
 }


### PR DESCRIPTION
Nix is a reproducible, deterministic, declarative package manager. Variable compile time inputs/outputs defeat the purpose.  This wraps the git revision and datetime inputs in a check for an environment variable present in the Nix build environment.  If so, the Nix package manager will provide the git revision correctly within its environment and a static datetime equal to the start of the Unix epoch (1970-01-01 00:00:00).